### PR TITLE
Fix compilations error debian/testing (gcc version 4.8.2)

### DIFF
--- a/libdash/qtsampleplayer/CMakeLists.txt
+++ b/libdash/qtsampleplayer/CMakeLists.txt
@@ -43,4 +43,4 @@ add_executable(qtsampleplayer ${qtplayer_SOURCE} ${qtsampleplayer_FORMS_HEADERS}
 qt5_use_modules(qtsampleplayer Core Widgets Multimedia MultimediaWidgets Gui OpenGL)
 
 # For the linker
-target_link_libraries(qtsampleplayer dash ${QT_LIBRARIES} ${LIBAV_LIBRARIES}) 
+target_link_libraries(qtsampleplayer dash ${QT_LIBRARIES} ${LIBAV_LIBRARIES} -lpthread)

--- a/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.h
+++ b/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.h
@@ -60,7 +60,7 @@
     #include <errno.h>
     #include <stdlib.h>
     #include <iostream>
-
+    #include <unistd.h>
     #define CRITICAL_SECTION    pthread_mutex_t
     #define CONDITION_VARIABLE  pthread_cond_t
 


### PR DESCRIPTION
- Fix issue while linking pthread: "DSO missing from command line"
- Add missing header required for usleep
