### PR TITLE
Fix pthread resource leak

### DIFF
--- a/libdash/libdash/source/portable/MultiThreading.cpp
+++ b/libdash/libdash/source/portable/MultiThreading.cpp
@@ -13,7 +13,12 @@ THREAD_HANDLE   CreateThreadPortable    (void *(*start_routine) (void *), void *
             return NULL;
         }
 
-        if(int err = pthread_create(th, NULL, start_routine, arg))
+        // Create pthread as detached so it'll free its resources at exit
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+        if(int err = pthread_create(th, &attr, start_routine, arg))
         {
             std::cerr << strerror(err) << std::endl;
             return NULL;

--- a/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.cpp
+++ b/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.cpp
@@ -13,7 +13,12 @@ THREAD_HANDLE   CreateThreadPortable    (void *(*start_routine) (void *), void *
             return NULL;
         }
 
-        if(int err = pthread_create(th, NULL, start_routine, arg))
+        // Create pthread as detached so it'll free its resources at exit
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+        if(int err = pthread_create(th, &attr, start_routine, arg))
         {
             std::cerr << strerror(err) << std::endl;
             return NULL;


### PR DESCRIPTION
We're using libdash's default segment download implementation on Linux to download 10+ adaptationsets simultaneously with 1 second segment length. The default implementation creates a new pthread instance for each segment but doesn't release thread resources (and stack 1-2MB/each?) when the download finishes. This resource leak killed our application in 3-5 minutes when testing with a machine with 2GB of RAM.

This fix creates pthreads as detached so they'll free resources automatically when thread function finishes.

More info: http://man7.org/linux/man-pages/man3/pthread_detach.3.html
" Either pthread_join(3) or pthread_detach() should be called for each thread that an application creates, so that system resources for the thread can be released. "