### PR TITLE
Fix bug where uri is empty as generated by MP4Box -single-file

### DIFF
--- a/libdash/libdash/source/mpd/Segment.cpp
+++ b/libdash/libdash/source/mpd/Segment.cpp
@@ -43,7 +43,7 @@ bool                Segment::Init               (const std::vector<IBaseUrl *>& 
 
     this->absoluteuri = Path::CombinePaths(this->absoluteuri, uri);
 
-    if (uri != "" && dash::helpers::Path::GetHostPortAndPath(this->absoluteuri, host, port, path))
+    if (this->absoluteuri != "" && dash::helpers::Path::GetHostPortAndPath(this->absoluteuri, host, port, path))
     {
         this->host = host;
         this->port = port;


### PR DESCRIPTION
Bug is reproducible using
MP4Box -dash 3000 -single-file merged.audio.mp4 -out single/audio.mpd
and will cause ToSegment() calls to return null erronously