### PR TITLE
Change the integer type to 64 bits on ITimeLine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 
 .metadata
 build
+.vscode

--- a/libdash/libdash/include/ISegmentTemplate.h
+++ b/libdash/libdash/include/ISegmentTemplate.h
@@ -126,7 +126,7 @@ namespace dash
                  *                                  This integer will be formated according to a possibly contained format tag in the \em \$Time\$ identifier.
                  *  @return     a pointer to a dash::mpd::ISegment object
                  */
-                virtual ISegment*           GetMediaSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const = 0;
+                virtual ISegment*           GetMediaSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const = 0;
 
                 /**
                  *  Returns a pointer to a dash::mpd::ISegment object that represents a Index Segment and can be downloaded.
@@ -140,7 +140,7 @@ namespace dash
                  *                                  This integer will be formated according to a possibly contained format tag in the \em \$Time\$ identifier.
                  *  @return     a pointer to a dash::mpd::ISegment object
                  */
-                virtual ISegment*           GetIndexSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const = 0;
+                virtual ISegment*           GetIndexSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const = 0;
         };
     }
 }

--- a/libdash/libdash/include/ITimeline.h
+++ b/libdash/libdash/include/ITimeline.h
@@ -43,7 +43,7 @@ namespace dash
                  *  \em StartTime corresponds to the \c \@t attribute.
                  *  @return     an unsigned integer
                  */
-                virtual uint32_t    GetStartTime    ()  const = 0;
+                virtual uint64_t    GetStartTime    ()  const = 0;
 
                 /**
                  *  Returns the integer that specifies the Segment duration, in units of the value of the \c \@timescale. \n\n

--- a/libdash/libdash/source/mpd/SegmentTemplate.cpp
+++ b/libdash/libdash/source/mpd/SegmentTemplate.cpp
@@ -11,6 +11,8 @@
 
 #include "SegmentTemplate.h"
 
+#include <inttypes.h>
+
 using namespace dash::mpd;
 using namespace dash::metrics;
 
@@ -73,15 +75,15 @@ ISegment*           SegmentTemplate::GetIndexSegmentFromNumber      (const std::
 {
     return ToSegment(this->index, baseurls, representationID, bandwidth, dash::metrics::IndexSegment, number);
 }
-ISegment*           SegmentTemplate::GetMediaSegmentFromTime        (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const
+ISegment*           SegmentTemplate::GetMediaSegmentFromTime        (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const
 {
     return ToSegment(this->media, baseurls, representationID, bandwidth, dash::metrics::MediaSegment, 0, time);
 }
-ISegment*           SegmentTemplate::GetIndexSegmentFromTime        (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const
+ISegment*           SegmentTemplate::GetIndexSegmentFromTime        (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const
 {
     return ToSegment(this->index, baseurls, representationID, bandwidth, dash::metrics::IndexSegment, 0, time);
 }
-std::string         SegmentTemplate::ReplaceParameters              (const std::string& uri, const std::string& representationID, uint32_t bandwidth, uint32_t number, uint32_t time) const
+std::string         SegmentTemplate::ReplaceParameters              (const std::string& uri, const std::string& representationID, uint32_t bandwidth, uint32_t number, uint64_t time) const
 {
     std::vector<std::string> chunks;
     std::string replacedUri = "";
@@ -139,7 +141,19 @@ void                SegmentTemplate::FormatChunk                    (std::string
     sprintf(formattedNumber, formatTag.c_str(), number);
     uri = formattedNumber;
 }
-ISegment*           SegmentTemplate::ToSegment                      (const std::string& uri, const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, HTTPTransactionType type, uint32_t number, uint32_t time) const
+void                SegmentTemplate::FormatChunk                    (std::string& uri, uint64_t number) const
+{
+    char formattedNumber [50];
+    size_t pos = 0;
+    std::string formatTag = "%01" PRIu64 "";
+
+    if ( (pos = uri.find("%0")) != std::string::npos)
+        formatTag = uri.substr(pos);
+
+    sprintf(formattedNumber, formatTag.c_str(), number);
+    uri = formattedNumber;
+}
+ISegment*           SegmentTemplate::ToSegment                      (const std::string& uri, const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, HTTPTransactionType type, uint32_t number, uint64_t time) const
 {
     Segment *seg = new Segment();
 

--- a/libdash/libdash/source/mpd/SegmentTemplate.cpp
+++ b/libdash/libdash/source/mpd/SegmentTemplate.cpp
@@ -134,7 +134,7 @@ void                SegmentTemplate::FormatChunk                    (std::string
     std::string formatTag = "%01d";
 
     if ( (pos = uri.find("%0")) != std::string::npos)
-        formatTag = uri.substr(pos).append("d");
+        formatTag = uri.substr(pos);
 
     sprintf(formattedNumber, formatTag.c_str(), number);
     uri = formattedNumber;

--- a/libdash/libdash/source/mpd/SegmentTemplate.h
+++ b/libdash/libdash/source/mpd/SegmentTemplate.h
@@ -36,8 +36,8 @@ namespace dash
                 ISegment*           ToBitstreamSwitchingSegment (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth) const;
                 ISegment*           GetMediaSegmentFromNumber   (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t number) const;
                 ISegment*           GetIndexSegmentFromNumber   (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t number) const;
-                ISegment*           GetMediaSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const;
-                ISegment*           GetIndexSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint32_t time) const;
+                ISegment*           GetMediaSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const;
+                ISegment*           GetIndexSegmentFromTime     (const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, uint64_t time) const;
 
                 void    SetMedia                (const std::string& media);
                 void    SetIndex                (const std::string& index);
@@ -45,10 +45,11 @@ namespace dash
                 void    SetBitstreamSwitching   (const std::string& bitstreamSwichting);
 
             private:
-                std::string ReplaceParameters   (const std::string& uri, const std::string& representationID, uint32_t bandwidth, uint32_t number, uint32_t time) const;
+                std::string ReplaceParameters   (const std::string& uri, const std::string& representationID, uint32_t bandwidth, uint32_t number, uint64_t time) const;
                 void        FormatChunk         (std::string& uri, uint32_t number) const;
+                void        FormatChunk         (std::string& uri, uint64_t number) const;
                 ISegment*   ToSegment           (const std::string& uri, const std::vector<IBaseUrl *>& baseurls, const std::string& representationID, uint32_t bandwidth, 
-                                                 dash::metrics::HTTPTransactionType type, uint32_t number = 0, uint32_t time = 0) const;
+                                                 dash::metrics::HTTPTransactionType type, uint32_t number = 0, uint64_t time = 0) const;
 
                 std::string media;
                 std::string index;

--- a/libdash/libdash/source/mpd/Timeline.cpp
+++ b/libdash/libdash/source/mpd/Timeline.cpp
@@ -23,11 +23,11 @@ Timeline::~Timeline   ()
 {
 }
 
-uint32_t    Timeline::GetStartTime     ()  const
+uint64_t    Timeline::GetStartTime     ()  const
 {
     return this->startTime;
 }
-void        Timeline::SetStartTime     (uint32_t startTime) 
+void        Timeline::SetStartTime     (uint64_t startTime) 
 {
     this->startTime = startTime;
 }

--- a/libdash/libdash/source/mpd/Timeline.h
+++ b/libdash/libdash/source/mpd/Timeline.h
@@ -27,16 +27,16 @@ namespace dash
                 Timeline             ();
                 virtual ~Timeline    ();
 
-                uint32_t    GetStartTime    ()  const;
+                uint64_t    GetStartTime    ()  const;
                 uint32_t    GetDuration     ()  const;
                 uint32_t    GetRepeatCount  ()  const;
 
-                void    SetStartTime    (uint32_t startTime);
+                void    SetStartTime    (uint64_t startTime);
                 void    SetDuration     (uint32_t duration);
                 void    SetRepeatCount  (uint32_t repeatCount);
 
             private:
-                uint32_t    startTime;
+                uint64_t    startTime;
                 uint32_t    duration;
                 uint32_t    repeatCount;
         };

--- a/libdash/libdash/source/portable/MultiThreading.cpp
+++ b/libdash/libdash/source/portable/MultiThreading.cpp
@@ -13,7 +13,12 @@ THREAD_HANDLE   CreateThreadPortable    (void *(*start_routine) (void *), void *
             return NULL;
         }
 
-        if(int err = pthread_create(th, NULL, start_routine, arg))
+        // Create pthread as detached so it'll free its resources at exit
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+        if(int err = pthread_create(th, &attr, start_routine, arg))
         {
             std::cerr << strerror(err) << std::endl;
             return NULL;

--- a/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.cpp
+++ b/libdash/qtsampleplayer/libdashframework/Portable/MultiThreading.cpp
@@ -13,7 +13,12 @@ THREAD_HANDLE   CreateThreadPortable    (void *(*start_routine) (void *), void *
             return NULL;
         }
 
-        if(int err = pthread_create(th, NULL, start_routine, arg))
+        // Create pthread as detached so it'll free its resources at exit
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+        if(int err = pthread_create(th, &attr, start_routine, arg))
         {
             std::cerr << strerror(err) << std::endl;
             return NULL;


### PR DESCRIPTION
This fix problems when get a live content with large Start Time (parameter `t`) on `SegmentTimeline`

Signed-off-by: Luis Felipe Domínguez Vega <ldominguezvega@gmail.com>