### PR TITLE
Build libdash on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 .metadata
 build
+
+.idea
+cmake-build-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,13 @@ matrix:
 
 script:
   - |
+      set -us
+
       mkdir -p libdash/cmake-build-${BUILD_TYPE}
       cd libdash/cmake-build-${BUILD_TYPE}
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
       make
 
-      export LD_LIBRARY_PATH=$(realpath ./bin)
+      export LD_LIBRARY_PATH=$(pwd)/bin
       ./bin/libdash_networkpart_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,88 @@
+language: c++
+
+env:
+  global:
+    - LD_LIBRARY_PATH=/usr/local/lib
+
+#addons:
+#  apt:
+#    sources: &common_sources
+#      - ubuntu-toolchain-r-test
+#    packages: &common_packages
+#      - build-essential
+#      - clang++
+#      - cmake
+#      - g++
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      dist: bionic
+      env:
+        - BUILD_TYPE=Debug
+    - os: linux
+      compiler: gcc
+      dist: xenial
+      env:
+        - BUILD_TYPE=Debug
+    - os: linux
+      compiler: gcc
+      dist: trusty
+      env:
+        - BUILD_TYPE=Debug
+
+    - os: linux
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_TYPE=Debug
+    - os: linux
+      compiler: clang
+      dist: xenial
+      env:
+        - BUILD_TYPE=Debug
+    - os: linux
+      compiler: clang
+      dist: trusty
+      env:
+        - BUILD_TYPE=Debug
+
+    - os: linux
+      compiler: gcc
+      dist: bionic
+      env:
+        - BUILD_TYPE=Release
+    - os: linux
+      compiler: gcc
+      dist: xenial
+      env:
+        - BUILD_TYPE=Release
+    - os: linux
+      compiler: gcc
+      dist: trusty
+      env:
+        - BUILD_TYPE=Release
+
+    - os: linux
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_TYPE=Release
+    - os: linux
+      compiler: clang
+      dist: xenial
+      env:
+        - BUILD_TYPE=Release
+    - os: linux
+      compiler: clang
+      dist: trusty
+      env:
+        - BUILD_TYPE=Release
+
+script:
+  - |
+      mkdir -p libdash/cmake-build-release
+      cd libdash/cmake-build-release
+      cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+      make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,9 @@
 language: c++
 
-env:
-  global:
-    - LD_LIBRARY_PATH=/usr/local/lib
-
-#addons:
-#  apt:
-#    sources: &common_sources
-#      - ubuntu-toolchain-r-test
-#    packages: &common_packages
-#      - build-essential
-#      - clang++
-#      - cmake
-#      - g++
-
 matrix:
   include:
+
+    # UBUNTU - DEBUG - GCC
     - os: linux
       compiler: gcc
       dist: bionic
@@ -32,6 +20,7 @@ matrix:
       env:
         - BUILD_TYPE=Debug
 
+    # UBUNTU - DEBUG - CLANG
     - os: linux
       compiler: clang
       dist: bionic
@@ -48,6 +37,7 @@ matrix:
       env:
         - BUILD_TYPE=Debug
 
+    # UBUNTU - RELEASE - GCC
     - os: linux
       compiler: gcc
       dist: bionic
@@ -64,6 +54,7 @@ matrix:
       env:
         - BUILD_TYPE=Release
 
+    # UBUNTU - RELEASE - CLANG
     - os: linux
       compiler: clang
       dist: bionic
@@ -82,7 +73,11 @@ matrix:
 
 script:
   - |
-      mkdir -p libdash/cmake-build-release
-      cd libdash/cmake-build-release
+      mkdir -p libdash/cmake-build-${BUILD_TYPE}
+      cd libdash/cmake-build-${BUILD_TYPE}
       cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+
       make
+
+      export LD_LIBRARY_PATH=$(realpath ./bin)
+      ./bin/libdash_networkpart_test

--- a/libdash/libdash_networkpart_test/libdash_networkpart_test.cpp
+++ b/libdash/libdash_networkpart_test/libdash_networkpart_test.cpp
@@ -91,6 +91,4 @@ int main()
     std::cout << "finished!" << std::endl << std::endl;
 
     delete(peristenthttpconnection);
-
-    getchar();
 }


### PR DESCRIPTION
# Description

Adds configuration files for Travis to have each PR validated.

Supported OS:
- Ubuntu 18.04
- Ubuntu 16.04
- Ubuntu 14.04

Supported build type:
- Debug
- Release

Supported compiler:
- gcc
- clang

More configurations (i.e OSX, Windows) should come after this contribution.



